### PR TITLE
Pass options through to GRPC.Stub.connect

### DIFF
--- a/lib/api/v1/client.ex
+++ b/lib/api/v1/client.ex
@@ -11,23 +11,34 @@ defmodule Authzed.Api.V1.Client do
 
   defstruct @keys
 
-  def new(endpoint, auth_header) when is_list(auth_header) do
-    {:ok, channel} = GRPC.Stub.connect(endpoint, headers: auth_header)
+  @doc """
+  Establishes a gRPC connection with the Authzed service.
+
+  ## Options:
+
+  https://hexdocs.pm/grpc/GRPC.Stub.html#connect/2-options
+  """
+  def new(endpoint, auth_header, opts \\ []) when is_list(auth_header) do
+    grpc_opts = Keyword.merge(opts, headers: auth_header)
+    {:ok, channel} = GRPC.Stub.connect(endpoint, grpc_opts)
     %__MODULE__{channel: channel}
   end
 
-  def new(endpoint, ssl_cred) do
-    {:ok, channel} = GRPC.Stub.connect(endpoint, cred: ssl_cred)
+  def new(endpoint, ssl_cred, opts \\ []) do
+    grpc_opts = Keyword.merge(opts, cred: ssl_cred)
+    {:ok, channel} = GRPC.Stub.connect(endpoint, grpc_opts)
     %__MODULE__{channel: channel}
   end
 
-  def new(host, port, auth_header) when is_list(auth_header) do
-    {:ok, channel} = GRPC.Stub.connect(host, port, headers: auth_header)
+  def new(host, port, auth_header, opts \\ []) when is_list(auth_header) do
+    grpc_opts = Keyword.merge(opts, headers: auth_header)
+    {:ok, channel} = GRPC.Stub.connect(host, port, grpc_opts)
     %__MODULE__{channel: channel}
   end
 
-  def new(host, port, ssl_cred) do
-    {:ok, channel} = GRPC.Stub.connect(host, port, cred: ssl_cred)
+  def new(host, port, ssl_cred, opts \\ []) do
+    grpc_opts = Keyword.merge(opts, cred: ssl_cred)
+    {:ok, channel} = GRPC.Stub.connect(host, port, grpc_opts)
     %__MODULE__{channel: channel}
   end
 end

--- a/lib/api/v1/client.ex
+++ b/lib/api/v1/client.ex
@@ -18,25 +18,27 @@ defmodule Authzed.Api.V1.Client do
 
   https://hexdocs.pm/grpc/GRPC.Stub.html#connect/2-options
   """
-  def new(endpoint, auth_header, opts \\ []) when is_list(auth_header) do
+  def new(endpoint, auth_header_or_ssl_cred, opts \\ [])
+
+  def new(endpoint, auth_header, opts) when is_list(auth_header) do
     grpc_opts = Keyword.merge(opts, headers: auth_header)
     {:ok, channel} = GRPC.Stub.connect(endpoint, grpc_opts)
     %__MODULE__{channel: channel}
   end
 
-  def new(endpoint, ssl_cred, opts \\ []) do
+  def new(endpoint, ssl_cred, opts) do
     grpc_opts = Keyword.merge(opts, cred: ssl_cred)
     {:ok, channel} = GRPC.Stub.connect(endpoint, grpc_opts)
     %__MODULE__{channel: channel}
   end
 
-  def new(host, port, auth_header, opts \\ []) when is_list(auth_header) do
+  def new(host, port, auth_header, opts) when is_list(auth_header) do
     grpc_opts = Keyword.merge(opts, headers: auth_header)
     {:ok, channel} = GRPC.Stub.connect(host, port, grpc_opts)
     %__MODULE__{channel: channel}
   end
 
-  def new(host, port, ssl_cred, opts \\ []) do
+  def new(host, port, ssl_cred, opts) do
     grpc_opts = Keyword.merge(opts, cred: ssl_cred)
     {:ok, channel} = GRPC.Stub.connect(host, port, grpc_opts)
     %__MODULE__{channel: channel}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Authzed.MixProject do
   use Mix.Project
 
-  @version "0.0.11"
+  @version "0.0.12"
   @repo_url "https://github.com/goodhamgupta/authzed_ex/"
 
   def project do


### PR DESCRIPTION
Adds an optional keyword list argument to `Authzed.Api.V1.Client.new` so that additional `GRPC.Stub.connect` options can be configured.