### PR TITLE
Add missing `Google.Rpc` types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           mix escript.install hex protobuf --force
           echo "/home/runner/.mix/escripts" >> $GITHUB_PATH
-      - uses: "bufbuild/buf-setup-action@v1.29.0"
+      - uses: "bufbuild/buf-action@v1"
       - name: "Generate & Diff Protos"
         run: |
           echo "/home/runner/.mix/escripts" >> $GITHUB_PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,11 +94,15 @@ jobs:
           mix escript.install hex protobuf --force
           echo "/home/runner/.mix/escripts" >> $GITHUB_PATH
       - uses: "bufbuild/buf-action@v1"
+        with:
+          setup_only: true
       - name: "Generate & Diff Protos"
         run: |
           echo "/home/runner/.mix/escripts" >> $GITHUB_PATH
           ./buf.gen.yaml
           mix format authzed/**/*.ex
+          mix format google/rpc/**/*.ex
           bash -c '[[ $(diff -qr authzed/api lib/api | grep "Only in authzed") -eq 0 ]]'
+          bash -c '[[ $(diff -qr google/rpc lib/google/rpc | grep "Only in google") -eq 0 ]]'
           mix format
           rm -rf authzed

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ authzed_ex-*.tar
 
 # Ignore buf generated schema
 authzed/*
+google/*

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ generate:
 	@echo "Generation successful"
 	@echo "Copying files to authzed/api folder..."
 	cp -r authzed/api/* lib/api/
+	@echo "Copying files to google/rpc folder..."
+	@mkdir -p lib/google
+	cp -r google/rpc lib/google/
 	@echo "Files moved successfully"
 	@echo "Removing generated files.."
 	rm -rf authzed

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,8 +1,12 @@
-#!/usr/bin/env -S buf generate buf.build/authzed/api:v1.33.0 --template
+#!/usr/bin/env -S buf generate --template
 ---
-version: "v1"
+version: "v2"
 plugins:
-  - name: "elixir"
+  - local: "protoc-gen-elixir"
     out: "."
     opt:
       - plugins=grpc
+inputs:
+  - module: "buf.build/authzed/api:v1.33.0 "
+  - module: "buf.build/googleapis/googleapis"
+    

--- a/lib/api/v0/core.pb.ex
+++ b/lib/api/v0/core.pb.ex
@@ -1,7 +1,7 @@
 defmodule Authzed.Api.V0.RelationTuple do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:object_and_relation, 1,
     type: Authzed.Api.V0.ObjectAndRelation,
@@ -15,7 +15,7 @@ end
 defmodule Authzed.Api.V0.ObjectAndRelation do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:namespace, 1, type: :string, deprecated: false)
   field(:object_id, 2, type: :string, json_name: "objectId", deprecated: false)
@@ -25,7 +25,7 @@ end
 defmodule Authzed.Api.V0.RelationReference do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:namespace, 1, type: :string, deprecated: false)
   field(:relation, 3, type: :string, deprecated: false)
@@ -34,7 +34,7 @@ end
 defmodule Authzed.Api.V0.User do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   oneof(:user_oneof, 0)
 

--- a/lib/api/v0/developer.pb.ex
+++ b/lib/api/v0/developer.pb.ex
@@ -1,7 +1,7 @@
 defmodule Authzed.Api.V0.LookupShareResponse.LookupStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:UNKNOWN_REFERENCE, 0)
   field(:FAILED_TO_LOOKUP, 1)
@@ -12,7 +12,7 @@ end
 defmodule Authzed.Api.V0.DeveloperError.Source do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:UNKNOWN_SOURCE, 0)
   field(:SCHEMA, 1)
@@ -25,7 +25,7 @@ end
 defmodule Authzed.Api.V0.DeveloperError.ErrorKind do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:UNKNOWN_KIND, 0)
   field(:PARSE_ERROR, 1)
@@ -42,7 +42,7 @@ end
 defmodule Authzed.Api.V0.FormatSchemaRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:schema, 1, type: :string)
 end
@@ -50,7 +50,7 @@ end
 defmodule Authzed.Api.V0.FormatSchemaResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:error, 1, type: Authzed.Api.V0.DeveloperError)
   field(:formatted_schema, 2, type: :string, json_name: "formattedSchema")
@@ -59,7 +59,7 @@ end
 defmodule Authzed.Api.V0.UpgradeSchemaRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:namespace_configs, 1, repeated: true, type: :string, json_name: "namespaceConfigs")
 end
@@ -67,7 +67,7 @@ end
 defmodule Authzed.Api.V0.UpgradeSchemaResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:error, 1, type: Authzed.Api.V0.DeveloperError)
   field(:upgraded_schema, 2, type: :string, json_name: "upgradedSchema")
@@ -76,7 +76,7 @@ end
 defmodule Authzed.Api.V0.ShareRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:schema, 1, type: :string)
   field(:relationships_yaml, 2, type: :string, json_name: "relationshipsYaml")
@@ -87,7 +87,7 @@ end
 defmodule Authzed.Api.V0.ShareResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:share_reference, 1, type: :string, json_name: "shareReference")
 end
@@ -95,7 +95,7 @@ end
 defmodule Authzed.Api.V0.LookupShareRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:share_reference, 1, type: :string, json_name: "shareReference")
 end
@@ -103,7 +103,7 @@ end
 defmodule Authzed.Api.V0.LookupShareResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:status, 1, type: Authzed.Api.V0.LookupShareResponse.LookupStatus, enum: true)
   field(:schema, 2, type: :string)
@@ -115,7 +115,7 @@ end
 defmodule Authzed.Api.V0.RequestContext do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:schema, 1, type: :string)
   field(:relationships, 2, repeated: true, type: Authzed.Api.V0.RelationTuple)
@@ -124,7 +124,7 @@ end
 defmodule Authzed.Api.V0.EditCheckRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:context, 1, type: Authzed.Api.V0.RequestContext)
 
@@ -138,7 +138,7 @@ end
 defmodule Authzed.Api.V0.EditCheckResult do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:relationship, 1, type: Authzed.Api.V0.RelationTuple)
   field(:is_member, 2, type: :bool, json_name: "isMember")
@@ -148,7 +148,7 @@ end
 defmodule Authzed.Api.V0.EditCheckResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:request_errors, 1,
     repeated: true,
@@ -166,7 +166,7 @@ end
 defmodule Authzed.Api.V0.ValidateRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:context, 1, type: Authzed.Api.V0.RequestContext)
   field(:validation_yaml, 3, type: :string, json_name: "validationYaml")
@@ -177,7 +177,7 @@ end
 defmodule Authzed.Api.V0.ValidateResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:request_errors, 1,
     repeated: true,
@@ -197,7 +197,7 @@ end
 defmodule Authzed.Api.V0.DeveloperError do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:message, 1, type: :string)
   field(:line, 2, type: :uint32)

--- a/lib/api/v1/core.pb.ex
+++ b/lib/api/v1/core.pb.ex
@@ -1,7 +1,7 @@
 defmodule Authzed.Api.V1.RelationshipUpdate.Operation do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:OPERATION_UNSPECIFIED, 0)
   field(:OPERATION_CREATE, 1)
@@ -12,7 +12,7 @@ end
 defmodule Authzed.Api.V1.AlgebraicSubjectSet.Operation do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:OPERATION_UNSPECIFIED, 0)
   field(:OPERATION_UNION, 1)
@@ -23,7 +23,7 @@ end
 defmodule Authzed.Api.V1.Relationship do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:resource, 1, type: Authzed.Api.V1.ObjectReference, deprecated: false)
   field(:relation, 2, type: :string, deprecated: false)
@@ -39,7 +39,7 @@ end
 defmodule Authzed.Api.V1.ContextualizedCaveat do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:caveat_name, 1, type: :string, json_name: "caveatName", deprecated: false)
   field(:context, 2, type: Google.Protobuf.Struct, deprecated: false)
@@ -48,7 +48,7 @@ end
 defmodule Authzed.Api.V1.SubjectReference do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:object, 1, type: Authzed.Api.V1.ObjectReference, deprecated: false)
   field(:optional_relation, 2, type: :string, json_name: "optionalRelation", deprecated: false)
@@ -57,7 +57,7 @@ end
 defmodule Authzed.Api.V1.ObjectReference do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:object_type, 1, type: :string, json_name: "objectType", deprecated: false)
   field(:object_id, 2, type: :string, json_name: "objectId", deprecated: false)
@@ -66,7 +66,7 @@ end
 defmodule Authzed.Api.V1.ZedToken do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:token, 1, type: :string, deprecated: false)
 end
@@ -74,7 +74,7 @@ end
 defmodule Authzed.Api.V1.Cursor do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:token, 1, type: :string, deprecated: false)
 end
@@ -82,7 +82,7 @@ end
 defmodule Authzed.Api.V1.RelationshipUpdate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:operation, 1,
     type: Authzed.Api.V1.RelationshipUpdate.Operation,
@@ -96,7 +96,7 @@ end
 defmodule Authzed.Api.V1.PermissionRelationshipTree do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   oneof(:tree_type, 0)
 
@@ -109,7 +109,7 @@ end
 defmodule Authzed.Api.V1.AlgebraicSubjectSet do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:operation, 1,
     type: Authzed.Api.V1.AlgebraicSubjectSet.Operation,
@@ -127,7 +127,7 @@ end
 defmodule Authzed.Api.V1.DirectSubjectSet do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:subjects, 1, repeated: true, type: Authzed.Api.V1.SubjectReference)
 end
@@ -135,7 +135,7 @@ end
 defmodule Authzed.Api.V1.PartialCaveatInfo do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:missing_required_context, 1,
     repeated: true,

--- a/lib/api/v1/debug.pb.ex
+++ b/lib/api/v1/debug.pb.ex
@@ -1,7 +1,7 @@
 defmodule Authzed.Api.V1.CheckDebugTrace.PermissionType do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:PERMISSION_TYPE_UNSPECIFIED, 0)
   field(:PERMISSION_TYPE_RELATION, 1)
@@ -11,7 +11,7 @@ end
 defmodule Authzed.Api.V1.CheckDebugTrace.Permissionship do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:PERMISSIONSHIP_UNSPECIFIED, 0)
   field(:PERMISSIONSHIP_NO_PERMISSION, 1)
@@ -22,7 +22,7 @@ end
 defmodule Authzed.Api.V1.CaveatEvalInfo.Result do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:RESULT_UNSPECIFIED, 0)
   field(:RESULT_UNEVALUATED, 1)
@@ -34,7 +34,7 @@ end
 defmodule Authzed.Api.V1.DebugInformation do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:check, 1, type: Authzed.Api.V1.CheckDebugTrace)
   field(:schema_used, 2, type: :string, json_name: "schemaUsed")
@@ -43,7 +43,7 @@ end
 defmodule Authzed.Api.V1.CheckDebugTrace.SubProblems do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:traces, 1, repeated: true, type: Authzed.Api.V1.CheckDebugTrace)
 end
@@ -51,7 +51,7 @@ end
 defmodule Authzed.Api.V1.CheckDebugTrace do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   oneof(:resolution, 0)
 
@@ -91,7 +91,7 @@ end
 defmodule Authzed.Api.V1.CaveatEvalInfo do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:expression, 1, type: :string)
   field(:result, 2, type: Authzed.Api.V1.CaveatEvalInfo.Result, enum: true)

--- a/lib/api/v1/error_reason.pb.ex
+++ b/lib/api/v1/error_reason.pb.ex
@@ -1,7 +1,7 @@
 defmodule Authzed.Api.V1.ErrorReason do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:ERROR_REASON_UNSPECIFIED, 0)
   field(:ERROR_REASON_SCHEMA_PARSE_ERROR, 1)

--- a/lib/api/v1/experimental_service.pb.ex
+++ b/lib/api/v1/experimental_service.pb.ex
@@ -1,7 +1,7 @@
 defmodule Authzed.Api.V1.BulkCheckPermissionRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:consistency, 1, type: Authzed.Api.V1.Consistency)
 
@@ -15,7 +15,7 @@ end
 defmodule Authzed.Api.V1.BulkCheckPermissionRequestItem do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:resource, 1, type: Authzed.Api.V1.ObjectReference, deprecated: false)
   field(:permission, 2, type: :string, deprecated: false)
@@ -26,7 +26,7 @@ end
 defmodule Authzed.Api.V1.BulkCheckPermissionResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:checked_at, 1, type: Authzed.Api.V1.ZedToken, json_name: "checkedAt", deprecated: false)
 
@@ -40,7 +40,7 @@ end
 defmodule Authzed.Api.V1.BulkCheckPermissionPair do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   oneof(:response, 0)
 
@@ -52,7 +52,7 @@ end
 defmodule Authzed.Api.V1.BulkCheckPermissionResponseItem do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:permissionship, 1,
     type: Authzed.Api.V1.CheckPermissionResponse.Permissionship,
@@ -70,7 +70,7 @@ end
 defmodule Authzed.Api.V1.BulkImportRelationshipsRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:relationships, 1, repeated: true, type: Authzed.Api.V1.Relationship, deprecated: false)
 end
@@ -78,7 +78,7 @@ end
 defmodule Authzed.Api.V1.BulkImportRelationshipsResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:num_loaded, 1, type: :uint64, json_name: "numLoaded")
 end
@@ -86,7 +86,7 @@ end
 defmodule Authzed.Api.V1.BulkExportRelationshipsRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:consistency, 1, type: Authzed.Api.V1.Consistency)
   field(:optional_limit, 2, type: :uint32, json_name: "optionalLimit", deprecated: false)
@@ -101,7 +101,7 @@ end
 defmodule Authzed.Api.V1.BulkExportRelationshipsResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:after_result_cursor, 1, type: Authzed.Api.V1.Cursor, json_name: "afterResultCursor")
   field(:relationships, 2, repeated: true, type: Authzed.Api.V1.Relationship)
@@ -110,7 +110,7 @@ end
 defmodule Authzed.Api.V1.ExperimentalReflectSchemaRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:consistency, 1, type: Authzed.Api.V1.Consistency)
 
@@ -124,7 +124,7 @@ end
 defmodule Authzed.Api.V1.ExperimentalReflectSchemaResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:definitions, 1, repeated: true, type: Authzed.Api.V1.ExpDefinition)
   field(:caveats, 2, repeated: true, type: Authzed.Api.V1.ExpCaveat)
@@ -134,7 +134,7 @@ end
 defmodule Authzed.Api.V1.ExpSchemaFilter do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:optional_definition_name_filter, 1,
     type: :string,
@@ -153,7 +153,7 @@ end
 defmodule Authzed.Api.V1.ExpDefinition do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:name, 1, type: :string)
   field(:comment, 2, type: :string)
@@ -164,7 +164,7 @@ end
 defmodule Authzed.Api.V1.ExpCaveat do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:name, 1, type: :string)
   field(:comment, 2, type: :string)
@@ -175,7 +175,7 @@ end
 defmodule Authzed.Api.V1.ExpCaveatParameter do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:name, 1, type: :string)
   field(:type, 2, type: :string)
@@ -185,7 +185,7 @@ end
 defmodule Authzed.Api.V1.ExpRelation do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:name, 1, type: :string)
   field(:comment, 2, type: :string)
@@ -201,7 +201,7 @@ end
 defmodule Authzed.Api.V1.ExpTypeReference do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   oneof(:typeref, 0)
 
@@ -215,7 +215,7 @@ end
 defmodule Authzed.Api.V1.ExpPermission do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:name, 1, type: :string)
   field(:comment, 2, type: :string)
@@ -225,7 +225,7 @@ end
 defmodule Authzed.Api.V1.ExperimentalComputablePermissionsRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:consistency, 1, type: Authzed.Api.V1.Consistency)
   field(:definition_name, 2, type: :string, json_name: "definitionName")
@@ -240,7 +240,7 @@ end
 defmodule Authzed.Api.V1.ExpRelationReference do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:definition_name, 1, type: :string, json_name: "definitionName")
   field(:relation_name, 2, type: :string, json_name: "relationName")
@@ -250,7 +250,7 @@ end
 defmodule Authzed.Api.V1.ExperimentalComputablePermissionsResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:permissions, 1, repeated: true, type: Authzed.Api.V1.ExpRelationReference)
   field(:read_at, 2, type: Authzed.Api.V1.ZedToken, json_name: "readAt")
@@ -259,7 +259,7 @@ end
 defmodule Authzed.Api.V1.ExperimentalDependentRelationsRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:consistency, 1, type: Authzed.Api.V1.Consistency)
   field(:definition_name, 2, type: :string, json_name: "definitionName")
@@ -269,7 +269,7 @@ end
 defmodule Authzed.Api.V1.ExperimentalDependentRelationsResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:relations, 1, repeated: true, type: Authzed.Api.V1.ExpRelationReference)
   field(:read_at, 2, type: Authzed.Api.V1.ZedToken, json_name: "readAt")
@@ -278,7 +278,7 @@ end
 defmodule Authzed.Api.V1.ExperimentalDiffSchemaRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:consistency, 1, type: Authzed.Api.V1.Consistency)
   field(:comparison_schema, 2, type: :string, json_name: "comparisonSchema")
@@ -287,7 +287,7 @@ end
 defmodule Authzed.Api.V1.ExperimentalDiffSchemaResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:diffs, 1, repeated: true, type: Authzed.Api.V1.ExpSchemaDiff)
   field(:read_at, 2, type: Authzed.Api.V1.ZedToken, json_name: "readAt")
@@ -296,7 +296,7 @@ end
 defmodule Authzed.Api.V1.ExpRelationSubjectTypeChange do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:relation, 1, type: Authzed.Api.V1.ExpRelation)
 
@@ -309,7 +309,7 @@ end
 defmodule Authzed.Api.V1.ExpCaveatParameterTypeChange do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:parameter, 1, type: Authzed.Api.V1.ExpCaveatParameter)
   field(:previous_type, 2, type: :string, json_name: "previousType")
@@ -318,7 +318,7 @@ end
 defmodule Authzed.Api.V1.ExpSchemaDiff do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   oneof(:diff, 0)
 

--- a/lib/api/v1/permission_service.pb.ex
+++ b/lib/api/v1/permission_service.pb.ex
@@ -1,7 +1,7 @@
 defmodule Authzed.Api.V1.LookupPermissionship do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:LOOKUP_PERMISSIONSHIP_UNSPECIFIED, 0)
   field(:LOOKUP_PERMISSIONSHIP_HAS_PERMISSION, 1)
@@ -11,7 +11,7 @@ end
 defmodule Authzed.Api.V1.Precondition.Operation do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:OPERATION_UNSPECIFIED, 0)
   field(:OPERATION_MUST_NOT_MATCH, 1)
@@ -21,7 +21,7 @@ end
 defmodule Authzed.Api.V1.DeleteRelationshipsResponse.DeletionProgress do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:DELETION_PROGRESS_UNSPECIFIED, 0)
   field(:DELETION_PROGRESS_COMPLETE, 1)
@@ -31,7 +31,7 @@ end
 defmodule Authzed.Api.V1.CheckPermissionResponse.Permissionship do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:PERMISSIONSHIP_UNSPECIFIED, 0)
   field(:PERMISSIONSHIP_NO_PERMISSION, 1)
@@ -42,7 +42,7 @@ end
 defmodule Authzed.Api.V1.LookupSubjectsRequest.WildcardOption do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:WILDCARD_OPTION_UNSPECIFIED, 0)
   field(:WILDCARD_OPTION_INCLUDE_WILDCARDS, 1)
@@ -52,7 +52,7 @@ end
 defmodule Authzed.Api.V1.Consistency do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   oneof(:requirement, 0)
 
@@ -86,7 +86,7 @@ end
 defmodule Authzed.Api.V1.RelationshipFilter do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:resource_type, 1, type: :string, json_name: "resourceType", deprecated: false)
 
@@ -113,7 +113,7 @@ end
 defmodule Authzed.Api.V1.SubjectFilter.RelationFilter do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:relation, 1, type: :string, deprecated: false)
 end
@@ -121,7 +121,7 @@ end
 defmodule Authzed.Api.V1.SubjectFilter do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:subject_type, 1, type: :string, json_name: "subjectType", deprecated: false)
   field(:optional_subject_id, 2, type: :string, json_name: "optionalSubjectId", deprecated: false)
@@ -135,7 +135,7 @@ end
 defmodule Authzed.Api.V1.ReadRelationshipsRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:consistency, 1, type: Authzed.Api.V1.Consistency)
 
@@ -152,7 +152,7 @@ end
 defmodule Authzed.Api.V1.ReadRelationshipsResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:read_at, 1, type: Authzed.Api.V1.ZedToken, json_name: "readAt", deprecated: false)
   field(:relationship, 2, type: Authzed.Api.V1.Relationship, deprecated: false)
@@ -162,7 +162,7 @@ end
 defmodule Authzed.Api.V1.Precondition do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:operation, 1, type: Authzed.Api.V1.Precondition.Operation, enum: true, deprecated: false)
   field(:filter, 2, type: Authzed.Api.V1.RelationshipFilter, deprecated: false)
@@ -171,7 +171,7 @@ end
 defmodule Authzed.Api.V1.WriteRelationshipsRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:updates, 1, repeated: true, type: Authzed.Api.V1.RelationshipUpdate, deprecated: false)
 
@@ -186,7 +186,7 @@ end
 defmodule Authzed.Api.V1.WriteRelationshipsResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:written_at, 1, type: Authzed.Api.V1.ZedToken, json_name: "writtenAt")
 end
@@ -194,7 +194,7 @@ end
 defmodule Authzed.Api.V1.DeleteRelationshipsRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:relationship_filter, 1,
     type: Authzed.Api.V1.RelationshipFilter,
@@ -220,7 +220,7 @@ end
 defmodule Authzed.Api.V1.DeleteRelationshipsResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:deleted_at, 1, type: Authzed.Api.V1.ZedToken, json_name: "deletedAt")
 
@@ -234,7 +234,7 @@ end
 defmodule Authzed.Api.V1.CheckPermissionRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:consistency, 1, type: Authzed.Api.V1.Consistency)
   field(:resource, 2, type: Authzed.Api.V1.ObjectReference, deprecated: false)
@@ -247,7 +247,7 @@ end
 defmodule Authzed.Api.V1.CheckPermissionResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:checked_at, 1, type: Authzed.Api.V1.ZedToken, json_name: "checkedAt", deprecated: false)
 
@@ -269,7 +269,7 @@ end
 defmodule Authzed.Api.V1.CheckBulkPermissionsRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:consistency, 1, type: Authzed.Api.V1.Consistency)
 
@@ -283,7 +283,7 @@ end
 defmodule Authzed.Api.V1.CheckBulkPermissionsRequestItem do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:resource, 1, type: Authzed.Api.V1.ObjectReference, deprecated: false)
   field(:permission, 2, type: :string, deprecated: false)
@@ -294,7 +294,7 @@ end
 defmodule Authzed.Api.V1.CheckBulkPermissionsResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:checked_at, 1, type: Authzed.Api.V1.ZedToken, json_name: "checkedAt", deprecated: false)
 
@@ -308,7 +308,7 @@ end
 defmodule Authzed.Api.V1.CheckBulkPermissionsPair do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   oneof(:response, 0)
 
@@ -320,7 +320,7 @@ end
 defmodule Authzed.Api.V1.CheckBulkPermissionsResponseItem do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:permissionship, 1,
     type: Authzed.Api.V1.CheckPermissionResponse.Permissionship,
@@ -338,7 +338,7 @@ end
 defmodule Authzed.Api.V1.ExpandPermissionTreeRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:consistency, 1, type: Authzed.Api.V1.Consistency)
   field(:resource, 2, type: Authzed.Api.V1.ObjectReference, deprecated: false)
@@ -348,7 +348,7 @@ end
 defmodule Authzed.Api.V1.ExpandPermissionTreeResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:expanded_at, 1, type: Authzed.Api.V1.ZedToken, json_name: "expandedAt")
   field(:tree_root, 2, type: Authzed.Api.V1.PermissionRelationshipTree, json_name: "treeRoot")
@@ -357,7 +357,7 @@ end
 defmodule Authzed.Api.V1.LookupResourcesRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:consistency, 1, type: Authzed.Api.V1.Consistency)
 
@@ -377,7 +377,7 @@ end
 defmodule Authzed.Api.V1.LookupResourcesResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:looked_up_at, 1, type: Authzed.Api.V1.ZedToken, json_name: "lookedUpAt")
   field(:resource_object_id, 2, type: :string, json_name: "resourceObjectId")
@@ -400,7 +400,7 @@ end
 defmodule Authzed.Api.V1.LookupSubjectsRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:consistency, 1, type: Authzed.Api.V1.Consistency)
   field(:resource, 2, type: Authzed.Api.V1.ObjectReference, deprecated: false)
@@ -433,7 +433,7 @@ end
 defmodule Authzed.Api.V1.LookupSubjectsResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:looked_up_at, 1, type: Authzed.Api.V1.ZedToken, json_name: "lookedUpAt")
   field(:subject_object_id, 2, type: :string, json_name: "subjectObjectId", deprecated: true)
@@ -471,7 +471,7 @@ end
 defmodule Authzed.Api.V1.ResolvedSubject do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:subject_object_id, 1, type: :string, json_name: "subjectObjectId")
 

--- a/lib/api/v1/schema_service.pb.ex
+++ b/lib/api/v1/schema_service.pb.ex
@@ -1,13 +1,13 @@
 defmodule Authzed.Api.V1.ReadSchemaRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 end
 
 defmodule Authzed.Api.V1.ReadSchemaResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:schema_text, 1, type: :string, json_name: "schemaText")
   field(:read_at, 2, type: Authzed.Api.V1.ZedToken, json_name: "readAt", deprecated: false)
@@ -16,7 +16,7 @@ end
 defmodule Authzed.Api.V1.WriteSchemaRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:schema, 1, type: :string, deprecated: false)
 end
@@ -24,7 +24,7 @@ end
 defmodule Authzed.Api.V1.WriteSchemaResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:written_at, 1, type: Authzed.Api.V1.ZedToken, json_name: "writtenAt", deprecated: false)
 end

--- a/lib/api/v1/watch_service.pb.ex
+++ b/lib/api/v1/watch_service.pb.ex
@@ -1,7 +1,7 @@
 defmodule Authzed.Api.V1.WatchRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:optional_object_types, 1,
     repeated: true,
@@ -25,7 +25,7 @@ end
 defmodule Authzed.Api.V1.WatchResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:updates, 1, repeated: true, type: Authzed.Api.V1.RelationshipUpdate)
   field(:changes_through, 2, type: Authzed.Api.V1.ZedToken, json_name: "changesThrough")

--- a/lib/api/v1alpha1/schema.pb.ex
+++ b/lib/api/v1alpha1/schema.pb.ex
@@ -1,7 +1,7 @@
 defmodule Authzed.Api.V1alpha1.ReadSchemaRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:object_definitions_names, 1,
     repeated: true,
@@ -14,7 +14,7 @@ end
 defmodule Authzed.Api.V1alpha1.ReadSchemaResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:object_definitions, 1, repeated: true, type: :string, json_name: "objectDefinitions")
 
@@ -27,7 +27,7 @@ end
 defmodule Authzed.Api.V1alpha1.WriteSchemaRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:schema, 1, type: :string, deprecated: false)
 
@@ -40,7 +40,7 @@ end
 defmodule Authzed.Api.V1alpha1.WriteSchemaResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:object_definitions_names, 1,
     repeated: true,

--- a/lib/api/v1alpha1/watchresources_service.pb.ex
+++ b/lib/api/v1alpha1/watchresources_service.pb.ex
@@ -1,7 +1,7 @@
 defmodule Authzed.Api.V1alpha1.PermissionUpdate.Permissionship do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:PERMISSIONSHIP_UNSPECIFIED, 0)
   field(:PERMISSIONSHIP_NO_PERMISSION, 1)
@@ -11,7 +11,7 @@ end
 defmodule Authzed.Api.V1alpha1.WatchResourcesRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:resource_object_type, 1,
     type: :string,
@@ -32,7 +32,7 @@ end
 defmodule Authzed.Api.V1alpha1.PermissionUpdate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:subject, 1, type: Authzed.Api.V1.SubjectReference)
   field(:resource, 2, type: Authzed.Api.V1.ObjectReference)
@@ -48,7 +48,7 @@ end
 defmodule Authzed.Api.V1alpha1.WatchResourcesResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field(:updates, 1, repeated: true, type: Authzed.Api.V1alpha1.PermissionUpdate)
   field(:changes_through, 2, type: Authzed.Api.V1.ZedToken, json_name: "changesThrough")

--- a/lib/google/rpc/code.pb.ex
+++ b/lib/google/rpc/code.pb.ex
@@ -1,0 +1,23 @@
+defmodule Google.Rpc.Code do
+  @moduledoc false
+
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:OK, 0)
+  field(:CANCELLED, 1)
+  field(:UNKNOWN, 2)
+  field(:INVALID_ARGUMENT, 3)
+  field(:DEADLINE_EXCEEDED, 4)
+  field(:NOT_FOUND, 5)
+  field(:ALREADY_EXISTS, 6)
+  field(:PERMISSION_DENIED, 7)
+  field(:UNAUTHENTICATED, 16)
+  field(:RESOURCE_EXHAUSTED, 8)
+  field(:FAILED_PRECONDITION, 9)
+  field(:ABORTED, 10)
+  field(:OUT_OF_RANGE, 11)
+  field(:UNIMPLEMENTED, 12)
+  field(:INTERNAL, 13)
+  field(:UNAVAILABLE, 14)
+  field(:DATA_LOSS, 15)
+end

--- a/lib/google/rpc/context/attribute_context.pb.ex
+++ b/lib/google/rpc/context/attribute_context.pb.ex
@@ -1,0 +1,174 @@
+defmodule Google.Rpc.Context.AttributeContext.Peer.LabelsEntry do
+  @moduledoc false
+
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :string)
+end
+
+defmodule Google.Rpc.Context.AttributeContext.Peer do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:ip, 1, type: :string)
+  field(:port, 2, type: :int64)
+
+  field(:labels, 6,
+    repeated: true,
+    type: Google.Rpc.Context.AttributeContext.Peer.LabelsEntry,
+    map: true
+  )
+
+  field(:principal, 7, type: :string)
+  field(:region_code, 8, type: :string, json_name: "regionCode")
+end
+
+defmodule Google.Rpc.Context.AttributeContext.Api do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:service, 1, type: :string)
+  field(:operation, 2, type: :string)
+  field(:protocol, 3, type: :string)
+  field(:version, 4, type: :string)
+end
+
+defmodule Google.Rpc.Context.AttributeContext.Auth do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:principal, 1, type: :string)
+  field(:audiences, 2, repeated: true, type: :string)
+  field(:presenter, 3, type: :string)
+  field(:claims, 4, type: Google.Protobuf.Struct)
+  field(:access_levels, 5, repeated: true, type: :string, json_name: "accessLevels")
+end
+
+defmodule Google.Rpc.Context.AttributeContext.Request.HeadersEntry do
+  @moduledoc false
+
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :string)
+end
+
+defmodule Google.Rpc.Context.AttributeContext.Request do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:id, 1, type: :string)
+  field(:method, 2, type: :string)
+
+  field(:headers, 3,
+    repeated: true,
+    type: Google.Rpc.Context.AttributeContext.Request.HeadersEntry,
+    map: true
+  )
+
+  field(:path, 4, type: :string)
+  field(:host, 5, type: :string)
+  field(:scheme, 6, type: :string)
+  field(:query, 7, type: :string)
+  field(:time, 9, type: Google.Protobuf.Timestamp)
+  field(:size, 10, type: :int64)
+  field(:protocol, 11, type: :string)
+  field(:reason, 12, type: :string)
+  field(:auth, 13, type: Google.Rpc.Context.AttributeContext.Auth)
+end
+
+defmodule Google.Rpc.Context.AttributeContext.Response.HeadersEntry do
+  @moduledoc false
+
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :string)
+end
+
+defmodule Google.Rpc.Context.AttributeContext.Response do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:code, 1, type: :int64)
+  field(:size, 2, type: :int64)
+
+  field(:headers, 3,
+    repeated: true,
+    type: Google.Rpc.Context.AttributeContext.Response.HeadersEntry,
+    map: true
+  )
+
+  field(:time, 4, type: Google.Protobuf.Timestamp)
+  field(:backend_latency, 5, type: Google.Protobuf.Duration, json_name: "backendLatency")
+end
+
+defmodule Google.Rpc.Context.AttributeContext.Resource.LabelsEntry do
+  @moduledoc false
+
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :string)
+end
+
+defmodule Google.Rpc.Context.AttributeContext.Resource.AnnotationsEntry do
+  @moduledoc false
+
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :string)
+end
+
+defmodule Google.Rpc.Context.AttributeContext.Resource do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:service, 1, type: :string)
+  field(:name, 2, type: :string)
+  field(:type, 3, type: :string)
+
+  field(:labels, 4,
+    repeated: true,
+    type: Google.Rpc.Context.AttributeContext.Resource.LabelsEntry,
+    map: true
+  )
+
+  field(:uid, 5, type: :string)
+
+  field(:annotations, 6,
+    repeated: true,
+    type: Google.Rpc.Context.AttributeContext.Resource.AnnotationsEntry,
+    map: true
+  )
+
+  field(:display_name, 7, type: :string, json_name: "displayName")
+  field(:create_time, 8, type: Google.Protobuf.Timestamp, json_name: "createTime")
+  field(:update_time, 9, type: Google.Protobuf.Timestamp, json_name: "updateTime")
+  field(:delete_time, 10, type: Google.Protobuf.Timestamp, json_name: "deleteTime")
+  field(:etag, 11, type: :string)
+  field(:location, 12, type: :string)
+end
+
+defmodule Google.Rpc.Context.AttributeContext do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:origin, 7, type: Google.Rpc.Context.AttributeContext.Peer)
+  field(:source, 1, type: Google.Rpc.Context.AttributeContext.Peer)
+  field(:destination, 2, type: Google.Rpc.Context.AttributeContext.Peer)
+  field(:request, 3, type: Google.Rpc.Context.AttributeContext.Request)
+  field(:response, 4, type: Google.Rpc.Context.AttributeContext.Response)
+  field(:resource, 5, type: Google.Rpc.Context.AttributeContext.Resource)
+  field(:api, 6, type: Google.Rpc.Context.AttributeContext.Api)
+  field(:extensions, 8, repeated: true, type: Google.Protobuf.Any)
+end

--- a/lib/google/rpc/error_details.pb.ex
+++ b/lib/google/rpc/error_details.pb.ex
@@ -1,0 +1,137 @@
+defmodule Google.Rpc.ErrorInfo.MetadataEntry do
+  @moduledoc false
+
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :string)
+end
+
+defmodule Google.Rpc.ErrorInfo do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:reason, 1, type: :string)
+  field(:domain, 2, type: :string)
+  field(:metadata, 3, repeated: true, type: Google.Rpc.ErrorInfo.MetadataEntry, map: true)
+end
+
+defmodule Google.Rpc.RetryInfo do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:retry_delay, 1, type: Google.Protobuf.Duration, json_name: "retryDelay")
+end
+
+defmodule Google.Rpc.DebugInfo do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:stack_entries, 1, repeated: true, type: :string, json_name: "stackEntries")
+  field(:detail, 2, type: :string)
+end
+
+defmodule Google.Rpc.QuotaFailure.Violation do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:subject, 1, type: :string)
+  field(:description, 2, type: :string)
+end
+
+defmodule Google.Rpc.QuotaFailure do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:violations, 1, repeated: true, type: Google.Rpc.QuotaFailure.Violation)
+end
+
+defmodule Google.Rpc.PreconditionFailure.Violation do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:type, 1, type: :string)
+  field(:subject, 2, type: :string)
+  field(:description, 3, type: :string)
+end
+
+defmodule Google.Rpc.PreconditionFailure do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:violations, 1, repeated: true, type: Google.Rpc.PreconditionFailure.Violation)
+end
+
+defmodule Google.Rpc.BadRequest.FieldViolation do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:field, 1, type: :string)
+  field(:description, 2, type: :string)
+end
+
+defmodule Google.Rpc.BadRequest do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:field_violations, 1,
+    repeated: true,
+    type: Google.Rpc.BadRequest.FieldViolation,
+    json_name: "fieldViolations"
+  )
+end
+
+defmodule Google.Rpc.RequestInfo do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:request_id, 1, type: :string, json_name: "requestId")
+  field(:serving_data, 2, type: :string, json_name: "servingData")
+end
+
+defmodule Google.Rpc.ResourceInfo do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:resource_type, 1, type: :string, json_name: "resourceType")
+  field(:resource_name, 2, type: :string, json_name: "resourceName")
+  field(:owner, 3, type: :string)
+  field(:description, 4, type: :string)
+end
+
+defmodule Google.Rpc.Help.Link do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:description, 1, type: :string)
+  field(:url, 2, type: :string)
+end
+
+defmodule Google.Rpc.Help do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:links, 1, repeated: true, type: Google.Rpc.Help.Link)
+end
+
+defmodule Google.Rpc.LocalizedMessage do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:locale, 1, type: :string)
+  field(:message, 2, type: :string)
+end

--- a/lib/google/rpc/status.pb.ex
+++ b/lib/google/rpc/status.pb.ex
@@ -1,0 +1,9 @@
+defmodule Google.Rpc.Status do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field(:code, 1, type: :int32)
+  field(:message, 2, type: :string)
+  field(:details, 3, repeated: true, type: Google.Protobuf.Any)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Authzed.MixProject do
   use Mix.Project
 
-  @version "1.0.0"
+  @version "1.0.1"
   @repo_url "https://github.com/goodhamgupta/authzed_ex/"
 
   def project do


### PR DESCRIPTION
This PR generates and copies some Google Rpc types into the Authzed library in response to a Dialyzer error that I saw once I started using the relatively new Bulk Permissions Check API.
```
lib/api/v1/permission_service.pb.ex:308:unknown_type
Unknown type: Google.Rpc.Status.t/0.
```

I admit that I am not confident we really want this type in _this_ package, and also that it feels like some tooling along the way maybe dropped the ball on this one because the Authzed `buf.yaml` states it depends on `googleapis` which is where this type comes from, so I would think that part of buf's job would be to generate code for that dependency.

Nonetheless, perhaps this is a reasonable short term solution since it doesn't cram too much more into this library and it addresses a bug that stops you from using otherwise useful Authzed APIs.

I am happy to revert the commit that simply reorders a bunch of lines of code; that change was made automatically on my machine, but it's clearly not substantive.