### PR TITLE
[Task]: Bump version to 1.5.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Authzed.MixProject do
   use Mix.Project
 
-  @version "1.4.0"
+  @version "1.5.0"
   @repo_url "https://github.com/goodhamgupta/authzed_ex/"
 
   def project do


### PR DESCRIPTION
The previous PR(https://github.com/goodhamgupta/authzed_ex/pull/32) bumped the authzed buf schema to v1.41.0, but the updated package version in `mix.exs` was missing.

Deploying it with the existing version number would overwrite the package on hex.pm, causing other users to force download this new change.

Hence, we are bumping up the package version to 1.5.0

cc: @tonnenpinguin 